### PR TITLE
[qmf-notifications-plugin] Delay notifications firing.

### DIFF
--- a/actionobserver.cpp
+++ b/actionobserver.cpp
@@ -32,6 +32,7 @@
 
 #include "actionobserver.h"
 #include <QtGlobal>
+#include <QTimer>
 #include <QDebug>
 
 // Utility function for debug proposes
@@ -214,8 +215,10 @@ void ActionObserver::actionsChanged(QList<QSharedPointer<QMailActionInfo> > acti
          if (_completedActions.size() > 0) {
              _completedActions.clear();
          }
-         // No more actions running
-         emit actionsCompleted();
+         // No more actions running, wait before emiting the signal,
+         // in case of mutiple accounts sync, new actions will start
+         // only after first ones are done.
+         QTimer::singleShot(1000, this, SLOT(emptyActionQueue()));
     }
 }
 
@@ -224,4 +227,11 @@ void ActionObserver::actionCompleted(quint64 id)
     Q_ASSERT(_runningActions.contains(id));
     _runningActions.remove(id);
     _completedActions.append(id);
+}
+
+void ActionObserver::emptyActionQueue()
+{
+    if (_runningActions.empty()) {
+        emit actionsCompleted();
+    }
 }

--- a/actionobserver.h
+++ b/actionobserver.h
@@ -77,6 +77,7 @@ signals:
 private slots:
     void actionsChanged(QList<QSharedPointer<QMailActionInfo> > actions);
     void actionCompleted(quint64 id);
+    void emptyActionQueue();
 
 private:
     bool isNotificationAction(QMailServerRequestType requestType);

--- a/rpm/qmf-notifications-plugin.spec
+++ b/rpm/qmf-notifications-plugin.spec
@@ -1,6 +1,6 @@
 Name:       qmf-notifications-plugin
 Summary:    Notifications plugin for Qt Messaging Framework (QMF)
-Version:    0.0.10
+Version:    0.0.11
 Release:    1
 Group:      System/Libraries
 License:    BSD


### PR DESCRIPTION
Delay notifications firing to avoid mutiple notifications when one
account is synced after another.
