### PR TITLE
[qmf-notifications-plugin] Removal all notifications items if there's more than one item published.

### DIFF
--- a/mailstoreobserver.cpp
+++ b/mailstoreobserver.cpp
@@ -320,9 +320,11 @@ void MailStoreObserver::publishNotifications(bool showPreview, int newCount)
 bool MailStoreObserver::publishedNotification()
 {
     QList<QObject*> publishedNotifications = _notification->notifications();
-    Q_ASSERT(publishedNotifications.size() < 2);
 
-    if (publishedNotifications.size() > 0) {
+    if (publishedNotifications.size() < 1) {
+        _publishedItemCount = 0;
+        return false;
+    } else if (publishedNotifications.size() == 1) {
         Notification *publishedNotification = static_cast<Notification*>(publishedNotifications.at(0));
         _replacesId = publishedNotification->replacesId();
         _publishedItemCount = publishedNotification->itemCount();
@@ -330,7 +332,15 @@ bool MailStoreObserver::publishedNotification()
         _notification->setReplacesId(_replacesId);
         return true;
     } else {
-         _publishedItemCount = 0;
+        for (int i = 0; i < publishedNotifications.size(); i++) {
+            Notification *publishedNotification = static_cast<Notification*>(publishedNotifications.at(i));
+            publishedNotification->close();
+        }
+        _publishedItemCount = 0;
+        _newMessagesCount = 0;
+        _oldMessagesCount = 0;
+        _publishedMessageList.clear();
+        qWarning() << Q_FUNC_INFO << "More than one notification published, closing all";
         return false;
     }
 }

--- a/rpm/qmf-notifications-plugin.spec
+++ b/rpm/qmf-notifications-plugin.spec
@@ -1,6 +1,6 @@
 Name:       qmf-notifications-plugin
 Summary:    Notifications plugin for Qt Messaging Framework (QMF)
-Version:    0.0.14
+Version:    0.0.15
 Release:    1
 Group:      System/Libraries
 License:    BSD


### PR DESCRIPTION
In a error case that more than one notification item gets published
by the same app(messageserver5) we clean everything, this is a rare
condition, only happens in case of a failure.
