### PR TITLE
Fix memory leak

### DIFF
--- a/mailstoreobserver.cpp
+++ b/mailstoreobserver.cpp
@@ -316,11 +316,13 @@ bool MailStoreObserver::publishedNotification()
                 _publishedItemCount = publishedNotification->itemCount();
                 _publishedMessages = publishedMessages;
                 _notification->setReplacesId(_replacesId);
+                qDeleteAll(publishedNotifications);
                 return true;
             }
         }
     }
     _publishedItemCount = 0;
+    qDeleteAll(publishedNotifications);
     return false;
 }
 
@@ -394,7 +396,9 @@ void MailStoreObserver::transmitCompleted(const QMailAccountId &accountId)
             }
         }
     }
+    qDeleteAll(publishedNotifications);
 }
+
 void MailStoreObserver::transmitFailed(const QMailAccountId &accountId)
 {
     QList<QObject*> publishedNotifications = _notification->notifications();
@@ -403,10 +407,13 @@ void MailStoreObserver::transmitFailed(const QMailAccountId &accountId)
         for (int i = 0; i < publishedNotifications.size(); i++) {
             Notification *publishedNotification = static_cast<Notification*>(publishedNotifications.at(i));
             if (publishedNotification->hintValue("x-nemo.email.sendFailed-accountId").toULongLong() == accountId.toULongLong()) {
+                qDeleteAll(publishedNotifications);
                 return;
             }
         }
     }
+
+    qDeleteAll(publishedNotifications);
 
     // Check if there are messages queued to send, transmition failed can be emitted for account testing or by other processes
     // working with the mail store.


### PR DESCRIPTION
Each Notification::notifications() call is allocating new objects which must be deleted by the caller:

==32157== 240 (44 direct, 196 indirect) bytes in 1 blocks are definitely lost in loss record 2,092 of 2,217
==32157==    at 0x4838424: operator new(unsigned int) (vg_replace_malloc.c:292)
==32157==    by 0x9858937: Notification::notifications() (notification.cpp:470)
==32157==    by 0x9814B3B: MailStoreObserver::publishedNotification() (mailstoreobserver.cpp:308)
==32157==    by 0x9818523: MailStoreObserver::actionsCompleted() (mailstoreobserver.cpp:333)
==32157==    by 0x981EFFF: MailStoreObserver::qt_static_metacall(QObject_, QMetaObject::Call, int, void__) (moc_mailstoreobserver.cpp:97)
==32157==    by 0x4DCC43F: QMetaObject::activate(QObject_, int, int, void**) (qobject.cpp:3580)
==32157==    by 0x981BE6B: ActionObserver::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_actionobserver.cpp:299)
==32157==    by 0x4DCC43F: QMetaObject::activate(QObject_, int, int, void__) (qobject.cpp:3580)
==32157==    by 0x4DD8C3F: QSingleShotTimer::timerEvent(QTimerEvent_) (qtimer.cpp:292)
