### PR TITLE
Fix memory leak

### DIFF
--- a/actionobserver.cpp
+++ b/actionobserver.cpp
@@ -248,7 +248,7 @@ void ActionObserver::actionsChanged(QList<QSharedPointer<QMailActionInfo> > acti
 void ActionObserver::actionCompleted(quint64 id)
 {
     Q_ASSERT(_runningActions.contains(id));
-    _runningActions.remove(id);
+    _runningActions.take(id)->deleteLater();
     _completedActions.append(id);
 }
 


### PR DESCRIPTION
RunningAction objects need to be deallocated after they are no longer needed. Otherwise they hang around until ActionObserver gets destroyed which it never does.
