### PR TITLE
[qmf-notifications-plugin] Update to libaccounts-qt version 1.13

### DIFF
--- a/rpm/qmf-notifications-plugin.spec
+++ b/rpm/qmf-notifications-plugin.spec
@@ -9,7 +9,7 @@ Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(qmfclient5)
 BuildRequires:  pkgconfig(qmfmessageserver5)
-BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(accounts-qt5) >= 1.13
 BuildRequires:  pkgconfig(nemotransferengine-qt5)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  qt5-qttools-linguist

--- a/src/accountscache.cpp
+++ b/src/accountscache.cpp
@@ -51,7 +51,7 @@ void AccountsCache::initCache()
     Accounts::AccountIdList accountIDList = _manager->accountListEnabled("e-mail");
 
     foreach (Accounts::AccountId accountId, accountIDList) {
-        Accounts::Account* account = _manager->account(accountId);
+        Accounts::Account* account = Accounts::Account::fromId(_manager, accountId, this);
         if (account->enabled()) {
             _accountsList.insert(accountId, account);
         } else {
@@ -62,7 +62,7 @@ void AccountsCache::initCache()
 
 bool AccountsCache::isEnabledMailAccount(const Accounts::AccountId accountId)
 {
-    QScopedPointer<Accounts::Account> account(_manager->account(accountId));
+    QScopedPointer<Accounts::Account> account(Accounts::Account::fromId(_manager, accountId, this));
     if (!account)
         return false;
 
@@ -79,7 +79,7 @@ bool AccountsCache::isEnabledMailAccount(const Accounts::AccountId accountId)
 void AccountsCache::accountCreated(Accounts::AccountId accountId)
 {
     if (isEnabledMailAccount(accountId)) {
-        Accounts::Account *account = _manager->account(accountId);
+        Accounts::Account *account = Accounts::Account::fromId(_manager, accountId, this);
         _accountsList.insert(accountId, account);
     }
 }
@@ -95,7 +95,7 @@ void AccountsCache::enabledEvent(Accounts::AccountId accountId)
 {
     if (isEnabledMailAccount(accountId)) {
         if (!_accountsList.contains(accountId)) {
-            Accounts::Account* account = _manager->account(accountId);
+            Accounts::Account* account = Accounts::Account::fromId(_manager, accountId, this);
             _accountsList.insert(accountId, account);
         }
     } else if (_accountsList.contains(accountId)) {


### PR DESCRIPTION
This commit ensures that we always use the Accounts::Account::fromId()
function instead of the Accounts::Manager::account() function to
create account instances, since we manually control the lifetime of
those instances.

The Accounts::Manager::account() behaviour was modified in
libaccounts-qt version 1.7 such that deleting the returned account
is unsafe.