### PR TITLE
Revert notification grouping changes in 1.1.6. Contributes to Mer#967

### DIFF
--- a/conf/x-nemo.email.conf
+++ b/conf/x-nemo.email.conf
@@ -1,4 +1,10 @@
 appIcon=icon-lock-email
 urgency=1
 x-nemo-icon=icon-lock-email
+x-nemo-preview-icon=icon-l-email
+x-nemo-feedback=email
+genericTextId=qtn_msg_notification_new_email
+genericTextCatalogue=email
 x-nemo-priority=100
+lowPowerModeIconId=icon-m-low-power-mode-email
+statusAreaIconId=icon-s-status-notifier-email

--- a/conf/x-nemo.email.error.conf
+++ b/conf/x-nemo.email.error.conf
@@ -1,5 +1,5 @@
 appIcon=icon-lock-email
 urgency=2
 x-nemo-icon=icon-lock-warning
-x-nemo-preview-icon=icon-lock-warning
+x-nemo-preview-icon-lock-warning
 x-nemo-priority=100

--- a/conf/x-nemo.email.summary.conf
+++ b/conf/x-nemo.email.summary.conf
@@ -1,6 +1,0 @@
-transient=true
-urgency=1
-x-nemo-icon=icon-lock-email
-x-nemo-preview-icon=icon-lock-email
-x-nemo-feedback=email
-x-nemo-priority=100

--- a/qmf-notifications-plugin.pro
+++ b/qmf-notifications-plugin.pro
@@ -3,10 +3,13 @@ TEMPLATE = subdirs
 SUBDIRS = src
 
 OTHER_FILES += \
-    conf/* \
+    conf/x-nemo.email.conf \
+    conf/x-nemo.email.error.conf \
     rpm/qmf-notifications-plugin.spec
 
-notifications_conf.files = conf/*
+notifications_conf.files = conf/x-nemo.email.conf
 notifications_conf.path = /usr/share/lipstick/notificationcategories/
+notifications_error_conf.files = conf/x-nemo.email.error.conf
+notifications_error_conf.path = /usr/share/lipstick/notificationcategories/
 
-INSTALLS += notifications_conf
+INSTALLS += notifications_conf notifications_error_conf

--- a/rpm/qmf-notifications-plugin.spec
+++ b/rpm/qmf-notifications-plugin.spec
@@ -33,7 +33,8 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %{_libdir}/qmf/plugins5/messageserverplugins/libnotifications.so
-%{_datadir}/lipstick/notificationcategories/*.conf
+%{_datadir}/lipstick/notificationcategories/x-nemo.email.conf
+%{_datadir}/lipstick/notificationcategories/x-nemo.email.error.conf
 
 %{_datadir}/translations/qmf-notifications_eng_en.qm
 

--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -48,7 +48,6 @@
 struct MessageInfo
 {
     QMailMessageId id;
-    QString origin;
     QString sender;
     QString subject;
     QDateTime timeStamp;
@@ -72,20 +71,31 @@ private slots:
     void setNotifyOff();
     
 private:
-    typedef QHash<QMailMessageId, QSharedPointer<MessageInfo> > MessageHash;
-
-    bool _publicationChanges;
+    int _newMessagesCount;
+    int _publishedItemCount;
+    int _oldMessagesCount;
     bool _appOnScreen;
+    uint _replacesId;
+    QString _publishedMessages;
     QMailStore *_storage;
-    MessageHash _publishedMessages;
-    QSet<QMailMessageId> _newMessages;
+    Notification *_notification;
+    QHash<QMailMessageId, QSharedPointer<MessageInfo> > _publishedMessageList;
+    QMailAccountIdList _enabledAccounts;
+    QMailMessageId _lastReceivedId;
 
-    void reloadNotifications();
     void closeNotifications();
-    QSharedPointer<MessageInfo> constructMessageInfo(const QMailMessageMetaData &message);
+    MessageInfo* constructMessageInfo(const QMailMessageMetaData &message);
+    QDateTime lastestPublishedMessageTimeStamp();
+    QSharedPointer<MessageInfo> messageInfo(const QMailMessageId id = QMailMessageId());
+    bool notificationsFromMultipleAccounts();
     bool notifyMessage(const QMailMessageMetaData &message);
     void notifyOnly();
-    void updateNotifications();
+    void reformatNotification(bool showPreview, int newCount);
+    void reformatPublishedMessages();
+    QString publishedMessageIds();
+    void publishNotifications(bool showPreview, int newCount);
+    bool publishedNotification();
+    void updateNotificationCount();
 };
 
 #endif // MAILSTOREOBSERVER_H


### PR DESCRIPTION
Notification grouping changes should not be included in the 1.1.6 release branch. Revert those changes.