### PR TITLE
[notifications] Do not close notifications on client launch. Contributes to MER#1002

### DIFF
--- a/src/mailstoreobserver.cpp
+++ b/src/mailstoreobserver.cpp
@@ -40,9 +40,13 @@
 
 namespace {
 
+const QString dbusService(QStringLiteral("com.jolla.email.ui"));
+const QString dbusPath(QStringLiteral("/com/jolla/email/ui"));
+const QString dbusInterface(QStringLiteral("com.jolla.email.ui"));
+
 QVariant remoteAction(const QString &name, const QString &displayName, const QString &method, const QVariantList &arguments = QVariantList())
 {
-    return Notification::remoteAction(name, displayName, "com.jolla.email.ui", "/com/jolla/email/ui", "com.jolla.email.ui", method, arguments);
+    return Notification::remoteAction(name, displayName, dbusService, dbusPath, dbusInterface, method, arguments);
 }
 
 QVariantList remoteActionList(const QString &name, const QString &displayName, const QString &method, const QVariantList &arguments = QVariantList())
@@ -75,10 +79,11 @@ MailStoreObserver::MailStoreObserver(QObject *parent) :
     reloadNotifications();
     updateNotifications();
 
-    QDBusConnection::sessionBus().connect(QString(), "/com/jolla/email/ui", "com.jolla.email.ui", "displayEntered",
-                                          this, SLOT(setNotifyOff()));
-    QDBusConnection::sessionBus().connect(QString(), "/com/jolla/email/ui", "com.jolla.email.ui", "displayExit",
-                                          this, SLOT(setNotifyOn()));
+    QDBusConnection dbusSession(QDBusConnection::sessionBus());
+    dbusSession.connect(QString(), dbusPath, dbusInterface, "displayEntered", this, SLOT(setNotifyOff()));
+    dbusSession.connect(QString(), dbusPath, dbusInterface, "displayExit", this, SLOT(setNotifyOn()));
+    dbusSession.connect(QString(), dbusPath, dbusInterface, "combinedInboxDisplayed", this, SLOT(combinedInboxDisplayed()));
+    dbusSession.connect(QString(), dbusPath, dbusInterface, "accountInboxDisplayed", this, SLOT(accountInboxDisplayed(int)));
 }
 
 void MailStoreObserver::reloadNotifications()
@@ -141,6 +146,25 @@ void MailStoreObserver::closeNotifications()
                 // We're no longer publishing these messages
                 foreach (const QString &id, messageIds.split(",", QString::SkipEmptyParts)) {
                     _publishedMessages.remove(QMailMessageId(id.toULongLong()));
+                }
+            }
+        }
+    }
+    qDeleteAll(existingNotifications);
+}
+
+void MailStoreObserver::closeAccountNotifications(const QMailAccountId &accountId)
+{
+    QList<QObject *> existingNotifications(Notification::notifications());
+    foreach (QObject *obj, existingNotifications) {
+        if (Notification *notification = qobject_cast<Notification *>(obj)) {
+            const QString publishedId(notification->hintValue("x-nemo.email.published-message-id").toString());
+            const QMailMessageId messageId(QMailMessageId(publishedId.toULongLong()));
+            if (messageId.isValid()) {
+                const QMailMessageMetaData message(messageId);
+                if (message.parentAccountId() == accountId) {
+                    notification->close();
+                    _publishedMessages.remove(messageId);
                 }
             }
         }
@@ -449,6 +473,19 @@ void MailStoreObserver::setNotifyOn()
 
 void MailStoreObserver::setNotifyOff()
 {
-    closeNotifications();
     _appOnScreen = true;
 }
+
+void MailStoreObserver::combinedInboxDisplayed()
+{
+    closeNotifications();
+}
+
+void MailStoreObserver::accountInboxDisplayed(int accountId)
+{
+    QMailAccountId acctId(accountId);
+    if (acctId.isValid()) {
+        closeAccountNotifications(acctId);
+    }
+}
+

--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -70,6 +70,8 @@ private slots:
     void transmitFailed(const QMailAccountId &accountId);
     void setNotifyOn();
     void setNotifyOff();
+    void combinedInboxDisplayed();
+    void accountInboxDisplayed(int accountId);
     
 private:
     typedef QHash<QMailMessageId, QSharedPointer<MessageInfo> > MessageHash;
@@ -82,6 +84,7 @@ private:
 
     void reloadNotifications();
     void closeNotifications();
+    void closeAccountNotifications(const QMailAccountId &accountId);
     QSharedPointer<MessageInfo> constructMessageInfo(const QMailMessageMetaData &message);
     bool notifyMessage(const QMailMessageMetaData &message);
     void notifyOnly();


### PR DESCRIPTION
Opening the email client should not close extant email notifications.