### PR TITLE
[notifications] Group emails under source account name. Contributes to MER#1045

### DIFF
--- a/conf/x-nemo.email.summary.conf
+++ b/conf/x-nemo.email.summary.conf
@@ -1,6 +1,5 @@
 transient=true
 urgency=1
-x-nemo-icon=icon-lock-email
-x-nemo-preview-icon=icon-lock-email
+appIcon=icon-lock-email
 x-nemo-feedback=email
 x-nemo-priority=100


### PR DESCRIPTION
Instead of 'Email', group email notifications by the name of their source account.