### PR TITLE
[qmf-notifications-plugin] Minimize processing on changes. Contributes to MER#1075

### DIFF
--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -81,6 +81,7 @@ private:
     QMailStore *_storage;
     MessageHash _publishedMessages;
     QSet<QMailMessageId> _newMessages;
+    QSet<QMailMessageId> _updatedMessages;
 
     void reloadNotifications();
     void closeNotifications();


### PR DESCRIPTION
When changes to emails are observed, only emails that have actually changed should have their associated notifications updated.