### PR TITLE
[qmf-notifications] Notify for new messages that do not cause an update event. Contributes to MER#1115

### DIFF
--- a/src/mailstoreobserver.cpp
+++ b/src/mailstoreobserver.cpp
@@ -228,7 +228,7 @@ void MailStoreObserver::updateNotifications()
         const MessageInfo *message(it.value().data());
 
         // Only republish this message if it has been updated
-        if (!_updatedMessages.contains(messageId))
+        if (!_updatedMessages.contains(messageId) && !_newMessages.contains(messageId))
             continue;
 
         Notification notification;


### PR DESCRIPTION
If a message is created by an addition event and does not cause a subsequent update event, it was not generating a notification.