### PR TITLE
[qmf-notifications] Limit the number of active notifications per account. Fixes MER#1241

### DIFF
--- a/src/mailstoreobserver.h
+++ b/src/mailstoreobserver.h
@@ -59,6 +59,8 @@ class MailStoreObserver : public QObject
 {
     Q_OBJECT
 public:
+    enum { MaxNotificationsPerAccount = 100 };
+
     explicit MailStoreObserver(QObject *parent = 0);
 
 private slots:


### PR DESCRIPTION
Ensure that we do not overload the notifications system by removing the oldest email notifications once a threshold value has been reached for each mail account.
